### PR TITLE
 Add a Dockefile for go 1.15.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,12 +38,12 @@ a single command to compile a Go package to various platforms and architectures.
 Although you could build the container manually, it is available as an automatic
 trusted build from Docker's container registry (not insignificant in size):
 
-    docker pull karalabe/xgo-latest
+    docker pull klaytn/xgo-latest
 
 To prevent having to remember a potentially complex Docker command every time,
 a lightweight Go wrapper was written on top of it.
 
-    go get github.com/karalabe/xgo
+    go get github.com/klaytn/xgo
 
 ## Usage
 
@@ -226,7 +226,7 @@ supported by the requested Android platform version. For iOS frameworks `xgo`
 will bundle armv7 and arm64 by default, and also the x86_64 simulator builds
 if the iPhoneSimulator.sdk was injected by the user:
 
-* Create a new docker image based on xgo: `FROM karalabe/xgo-latest`
+* Create a new docker image based on xgo: `FROM klaytn/xgo-latest`
 * Inject the simulator SDK: `ADD iPhoneSimulator9.3.sdk.tar.xz /iPhoneSimulator9.3.sdk.tar.xz`
 * Bootstrap the simulator SDK: `$UPDATE_IOS /iPhoneSimulator9.3.sdk.tar.xz`
 

--- a/docker/go-1.15.7/Dockerfile
+++ b/docker/go-1.15.7/Dockerfile
@@ -1,0 +1,23 @@
+# Go cross compiler (xgo): Go 1.15.7
+# Copyright (c) 2021 The klaytn Authors. All rights reserved.
+#
+# Released under the MIT license.
+
+FROM karalabe/xgo-base
+
+MAINTAINER Choah Jade Jung <jade.jung@groundx.xyz>
+
+# Configure the root Go distribution and bootstrap based on it
+ENV GO_VERSION 11507
+
+RUN \
+  export ROOT_DIST=https://storage.googleapis.com/golang/go1.15.7.linux-amd64.tar.gz && \
+  export ROOT_DIST_SHA=0d142143794721bb63ce6c8a6180c4062bcf8ef4715e7d6d6609f3a8282629b3 && \
+  \
+  sed -i '/darwin\/386/d' $BOOTSTRAP_PURE && \
+  sed -i '/darwin GOARCH=386/d' $BOOTSTRAP_PURE && \
+  sed -i 's/karalabe\/xgo/klaytn\/xgo/' $BOOTSTRAP_PURE && \
+  \
+  sed -i '483,488d' $BUILD && \
+  \
+  $BOOTSTRAP_PURE

--- a/xgo.go
+++ b/xgo.go
@@ -39,7 +39,7 @@ func init() {
 }
 
 // Cross compilation docker containers
-var dockerBase = "karalabe/xgo-base"
+//var dockerBase = "karalabe/xgo-base"
 var dockerDist = "klaytn/xgo-"
 
 // Command line arguments to fine tune the compilation


### PR DESCRIPTION
1. Change git/docker path from karalabe to klaytn
2. Add a Dockefile for go 1.15.7
 2-1. Update go version to 1.15.7
 2-2. Remove few lines of `bootstrap_pure.sh` in docker base(karalabe/xgo-base) to skip building standard library for darwin/386
 2-3. Remove few lines of `build.sh` in docker base(karalabe/xgo-base) to disable cross compiling for darwin/386